### PR TITLE
Implement ExecutionTracingProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Python
 *.py[cod]
 __pycache__/
+venv/
 
 # Bazel
 /.bazelrc

--- a/tensorflow_federated/python/core/utils/BUILD
+++ b/tensorflow_federated/python/core/utils/BUILD
@@ -133,6 +133,22 @@ py_library(
         "//tensorflow_federated/python/core/impl/executors:federating_executor",
         "//tensorflow_federated/python/core/impl/executors:reference_resolving_executor",
         "//tensorflow_federated/python/core/impl/executors:remote_executor",
+        "//tensorflow_federated/python/core/impl/executors:sizing_executor",
+        "//tensorflow_federated/python/core/impl/executors:thread_delegating_executor",
+        "//tensorflow_federated/python/core/impl/executors:transforming_executor",
+    ],
+)
+
+py_test(
+    name = "execution_tracing_test",
+    size = "small",
+    srcs = ["execution_tracing_test.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        ":execution_tracing",
+        "//tensorflow_federated/python/common_libs:test",
+        "//tensorflow_federated/python/common_libs:tracing",
     ],
 )
 

--- a/tensorflow_federated/python/core/utils/BUILD
+++ b/tensorflow_federated/python/core/utils/BUILD
@@ -17,6 +17,7 @@ py_library(
         ":computation_utils",
         ":differential_privacy",
         ":encoding_utils",
+        ":execution_tracing",
         ":federated_aggregations",
         ":tf_computation_utils",
         "//tensorflow_federated/python/core/templates:iterative_process",
@@ -112,6 +113,26 @@ py_test(
         "//tensorflow_federated/python/core/api:computations",
         "//tensorflow_federated/python/core/api:placements",
         "//tensorflow_federated/python/core/impl/executors:default_executor",
+    ],
+)
+
+py_library(
+    name = "execution_tracing",
+    srcs = ["execution_tracing.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow_federated/proto/v0:computation_py_pb2",
+        "//tensorflow_federated/python/common_libs:anonymous_tuple",
+        "//tensorflow_federated/python/common_libs:tracing",
+        "//tensorflow_federated/python/core/api:computation_types",
+        "//tensorflow_federated/python/core/impl:computation_impl",
+        "//tensorflow_federated/python/core/impl/compiler:intrinsic_defs",
+        "//tensorflow_federated/python/core/impl/executors:caching_executor",
+        "//tensorflow_federated/python/core/impl/executors:composing_executor",
+        "//tensorflow_federated/python/core/impl/executors:eager_tf_executor",
+        "//tensorflow_federated/python/core/impl/executors:federating_executor",
+        "//tensorflow_federated/python/core/impl/executors:reference_resolving_executor",
+        "//tensorflow_federated/python/core/impl/executors:remote_executor",
     ],
 )
 

--- a/tensorflow_federated/python/core/utils/execution_tracing.py
+++ b/tensorflow_federated/python/core/utils/execution_tracing.py
@@ -1,0 +1,270 @@
+from enum import Enum
+import functools
+import logging
+import re
+
+from tensorflow.python.framework.ops import EagerTensor as tf_EagerTensor
+
+from tensorflow_federated.proto.v0 import computation_pb2
+from tensorflow_federated.python.common_libs import anonymous_tuple
+from tensorflow_federated.python.common_libs import tracing
+from tensorflow_federated.python.core.api import computation_types
+from tensorflow_federated.python.core.impl import computation_impl
+from tensorflow_federated.python.core.impl.compiler import intrinsic_defs
+from tensorflow_federated.python.core.impl.executors import caching_executor
+from tensorflow_federated.python.core.impl.executors import composing_executor
+from tensorflow_federated.python.core.impl.executors import eager_tf_executor
+from tensorflow_federated.python.core.impl.executors import federating_executor
+from tensorflow_federated.python.core.impl.executors import reference_resolving_executor
+from tensorflow_federated.python.core.impl.executors import remote_executor
+
+
+class TraceFilterMode(Enum):
+  VALUES = 0
+  INTRINSICS = 1
+  ALL = 2
+
+
+def pattern_union(*patterns):
+  pattern_strs = map(lambda p: p.pattern, patterns)
+  return re.compile("|".join(pattern_strs))
+
+
+_VALUE_PATTERN = re.compile('^create_([a-z]+)$')
+_INTRINSIC_PATTERN = re.compile('^_compute_intrinsic_([a-z]+)$')
+
+_TRACE_FILTER_PATTERNS = {
+    TraceFilterMode.VALUES: _VALUE_PATTERN,
+    TraceFilterMode.INTRINSICS: pattern_union(
+        _VALUE_PATTERN, _INTRINSIC_PATTERN),
+    TraceFilterMode.ALL: None,
+}
+
+DEFAULT_FORMAT_STRATEGY = lambda x: "{} {}".format(x, type(x))
+
+
+class ExecutionTracingProvider(tracing.TracingProvider):
+  """Traces a subset of functions appearing in the current execution context.
+
+  This implementation does not require storing additional trace context state,
+  so most methods are no-ops.
+  """
+
+  def __init__(
+      self,
+      trace_filter_mode=TraceFilterMode.INTRINSICS,
+      default_format_strategy=DEFAULT_FORMAT_STRATEGY):
+    assert isinstance(trace_filter_mode, TraceFilterMode)
+
+    # establish what we're tracing
+    self._is_traceable_regex = _TRACE_FILTER_PATTERNS[trace_filter_mode]
+
+    # fill in formatting strategies
+    self._default_strategy = default_format_strategy
+    self._formatting_strategies = self._generate_formatting_strategies()
+
+    # indentation management
+    self._current_call_level = 0
+
+
+  def trace(self, fn=None, **kwargs):
+    """Decorate a method with tracing.
+
+    Works with async or regular functions. If no kwargs specified, can be used
+    without parens. Parameters accepted in kwargs depends on the implementation
+    vary across platforms.
+
+    Args:
+      fn: The function to decorate.
+      **kwargs: Options for configuring the trace.
+
+    Returns:
+      The decorated function.
+    """
+
+    class_name, method_name = tracing.func_to_class_and_method(fn)
+
+    regex = self._is_traceable_regex
+    force_trace = regex is None
+    if not self._is_traceable(method_name, regex, override=force_trace):
+      return fn
+
+    logging.debug('Decorating sync method: %s.%s', class_name, method_name)
+
+    def _pre_fn(*args, **kwargs):
+      self._trace_method(fn, "call")(*args, **kwargs)
+      self._current_call_level += 1
+
+    def _post_fn(*args, **kwargs):
+      self._trace_method(fn, "retr")(*args, **kwargs)
+      self._current_call_level -= 1
+
+    if inspect.iscoroutinefunction(fn):
+
+      @functools.wraps(fn)
+      async def async_fn(*args, **kwargs):
+        _pre_fn(*args, **kwargs)
+        retval = await fn(*args, **kwargs)
+        _post_fn(*args, **kwargs)
+        return retval
+
+      return async_fn
+
+    else:
+
+      @functools.wraps(fn)
+      def sync_fn(*args, **kwargs):
+        _pre_fn(*args, **kwargs)
+        retval = fn(*args, **kwargs)
+        _post_fn(*args, **kwargs)
+        return retval
+
+      return sync_fn
+
+  def span(self, unused_scope, unused_sub_scope, **unused_trace_opts):
+    """"No-op implementation of span."""
+
+    class NoSuchError(Exception):
+      pass
+
+    # contextlib.suppress(NoSuchError) is used to create a no-op Context and
+    # should be replaced by contextlib.nullcontext when it becomes available.
+    return contextlib.suppress(NoSuchError)
+
+  def task_trace_context(self):
+    """No-op implementation of task_trace_context."""
+
+    class NoSuchError(Exception):
+      pass
+
+    # contextlib.suppress(NoSuchError) is used to create a no-op Context and
+    # should be replaced by contextlib.nullcontext when it is available.
+    return contextlib.suppress(NoSuchError)
+
+  def propagate_trace_context_task_factory(self, loop, coro):
+    """No-op implementation of propagate_trace_context_task_factory."""
+    return asyncio.tasks.Task(coro, loop=loop)
+
+  def run_coroutine_threadsafe_in_ambient_trace_context(self, coro, loop):
+    """No-op implementation of run_coroutine_threadsafe_in_ambient_trace_context."""
+    return asyncio.run_coroutine_threadsafe(coro, loop)
+
+  def run_coroutine_threadsafe_in_task_trace_context(self, coro, loop):
+    """No-op implementation of run_coroutine_threadsafe_in_ambient_trace_context."""
+    return asyncio.run_coroutine_threadsafe(coro, loop)
+
+  def run_coroutine_in_ambient_trace_context(self, coro):
+    """No-op implementation of run_coroutine_in_ambient_trace_context."""
+    return coro
+
+  @classmethod
+  def _is_traceable(cls, method_name, regex, override=False):
+    if override:
+      return True
+    return regex.search(method_name)
+
+  def _trace_method(self, fn, call_or_retr):
+    ctx = getattr(fn, '__self__', None)
+
+    def _log_fn(*args, **kwargs):
+      prefix_str = self._prefix(ctx, class_name)
+      main_str = "{m} {c}".format(m=method_name, c=call_or_retr)
+      suffix_args = " ".join(self.format_object(a) for a in args)
+      suffix_kwargs = " ".join(self.format_object(v) for k,v in kwargs.items())
+      logging.debug("{p} {m} {sa} {sk}".format(
+          p=prefix_str,
+          m=main_str,
+          sa=suffix_args,
+          sk=suffix_kwargs))
+
+    return _log_fn
+
+  def _prefix(self, ctx, type_):
+    indentation = '  ' * self._current_call_level
+    template = "{indentation}{type} {hash}"
+    if ctx is None:
+      return template.format(indentation=indentation, type=type_, hash="NO_ID")
+    return template.format(indentation=indentation, type=type_, hash=hash(ctx))
+
+  def _format_object(self, x):
+    strategy = self._formatting_strategies.get(type(x), self._default_strategy)
+    return strategy(x)
+
+  def _format_anon_tuple(self, tup):
+    names = tup._name_array
+    values = tup._element_array
+    fmt_strs = []
+    for n, v in zip(names, values):
+      fmt_strs.append("{}: {}".format(n, self.format_object(v)))
+    return "({})".format(", ".join(fmt_strs))
+
+  #
+  # Registration of built-in types
+  #
+  def _register_formatting_strategy(self, type_, formatting_strategy):
+    self._formatting_strategies[type_] = formatting_strategy
+
+  def _generate_formatting_strategies(self):
+    self.register_executor_values()
+    self.register_computations()
+    self.register_computation_types()
+    self.register_primitives()
+
+  def register_executor_values(self):
+    register = self._register_formatting_strategy
+
+    for type_ in [
+        caching_executor.CachingExecutorValue,
+        composing_executor.ComposingExecutorValue,
+        eager_tf_executor.EagerValue,
+        federating_executor.FederatingExecutorValue,
+        reference_resolving_executor.ReferenceResolvingExecutorValue,
+        remote_executor.RemoteValue,
+    ]:
+      register(type_, lambda x: "<{} @{} : {}>".format(
+          type_.__name__, id(x), str(x.type_signature)))
+
+  def register_computation_types(self):
+    register = self._register_formatting_strategy
+
+    for type_ in [
+        computation_types.TensorType,
+        computation_types.FederatedType,
+        computation_types.FunctionType,
+        computation_types.SequenceType,
+    ]:
+      register(type_, lambda x: "<{}>".format(x))
+
+  def register_primitives(self):
+    register = self._register_formatting_strategy
+
+    register(float, lambda x: "<{} : float>".format(x))
+    register(int, lambda x: "<{} : int>".format(x))
+    register(type(None), lambda _: "-")
+    register(list, lambda x: [self.format_object(xi) for xi in x])
+    register(tuple, lambda x: tuple(self.format_object(xi) for xi in x))
+
+    register(tf_EagerTensor,
+        lambda x: "<{} @{}>".format(tf_EagerTensor.__name__, id(x)))
+
+    register(anonymous_tuple.AnonymousTuple,
+        lambda x: "<AnonymousTuple @{} : {}>".format(
+            id(x), self._format_anon_tuple(x)))
+
+  def register_computations(self):
+    register = self._register_formatting_strategy
+
+    register(computation_impl.ComputationImpl,
+        lambda x: "<ComputationImpl {} @{} : {}>".format(
+            x._computation_proto.WhichOneof('computation'),
+            id(x),
+            x.type_signature
+        ))
+
+    register(computation_pb2.Computation,
+        lambda x: "<ComputationPb {} @{} : {}>".format(
+            x.WhichOneof('computation'), id(x), x.type.WhichOneof('type')))
+
+    register(intrinsic_defs.IntrinsicDef,
+        lambda x: "<IntrinsicDef {} {} @{}>".format(
+            x.uri, x.type_signature, id(x)))

--- a/tensorflow_federated/python/core/utils/execution_tracing_test.py
+++ b/tensorflow_federated/python/core/utils/execution_tracing_test.py
@@ -1,0 +1,93 @@
+# Lint as: python3
+# Copyright 2019, The TensorFlow Federated Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import parameterized
+import logging
+import numpy as np
+import tempfile
+import tensorflow as tf
+
+from tensorflow_federated.python.common_libs import test
+from tensorflow_federated.python.common_libs import tracing
+from tensorflow_federated.python.core.utils import execution_tracing
+
+
+mock_repr = "mock!"
+
+class Mock:
+  def __repr__(self):
+    return mock_repr
+
+  @tracing.trace
+  def create_value(self, x):
+    return x
+
+  @tracing.trace
+  def _compute_intrinsic_blah_blah(self, x):
+    arg = self.create_value(x)
+    res = self._weird_other_method(arg)
+    return res
+
+  @tracing.trace
+  def _weird_other_method(self, x):
+    @tracing.trace
+    def _weird_nested_trace(y):
+      return y
+
+    return _weird_nested_trace(x)
+
+
+expected_mock_format = "{} {}".format(mock_repr, Mock)
+modified_format_strategy = lambda x: "hello from {x}".format(x=x)
+
+
+class ExecutionTracingProviderTest(test.TestCase, parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      ('default', execution_tracing.DEFAULT_FORMAT_STRATEGY,
+          expected_mock_format),
+      ('modified', modified_format_strategy, "hello from mock!"),
+  )
+  def test_default_formatting_strategy(self, strategy, expected):
+    obj = Mock()
+    tracer = execution_tracing.ExecutionTracingProvider(
+        default_format_strategy=strategy)
+    self.assertEqual(tracer._format_object(obj), expected)
+
+
+  @parameterized.named_parameters(
+      ('values', execution_tracing.TraceFilterMode.VALUES,
+          [True, False, False]),
+      ('intrinsics', execution_tracing.TraceFilterMode.INTRINSICS,
+          [True, True, False]),
+      ('all', execution_tracing.TraceFilterMode.ALL,
+          [True] * 3)
+  )
+  def test_trace_filter_mode(self, mode, expected):
+    obj = Mock()
+    testable_methods = [
+        'create_value',
+        '_compute_intrinsic_blah_blah',
+        '_weird_other_method',
+    ]
+    tracer = execution_tracing.ExecutionTracingProvider(trace_filter_mode=mode)
+    regex = tracer._is_traceable_regex
+    override = regex is None
+    result = [tracer._is_traceable(m, regex, override) for m in testable_methods]
+    self.assertAllEqual(result, expected)
+
+
+if __name__ == '__main__':
+  test.main()


### PR DESCRIPTION
Implements a TracingProvider that reproduces the logging from tf-encrypted/rfcs#23 etc.

Currently the Bazel build isn't working, so I can't test it on a real TFF computation. I imagine I will have some debugging work to do once that's fixed.